### PR TITLE
Deposit points

### DIFF
--- a/Osmalyzer/Analyzers/BottleDepositPointsAnalyzer.cs
+++ b/Osmalyzer/Analyzers/BottleDepositPointsAnalyzer.cs
@@ -66,11 +66,11 @@ public class BottleDepositPointsAnalyzer : Analyzer
 
         DepositPointsAnalysisData depositPointData = datas.OfType<DepositPointsAnalysisData>().First();
 
-        List<AutomatedDepositLocation> listedAutomatedDepositLocations = depositPointData.AutomatedDepositLocations;
+        List<AutomatedDepositLocation> listedDepositKiosks = depositPointData.DepositKiosk;
         List<ManualDepositLocation> listedManualDepositLocations = depositPointData.ManualDepositLocations;
         List<DepositAutomat> listedDepositAutomats = depositPointData.DepositAutomats;
 
-        Correlate(osmAutomatedDepositLoactions, listedAutomatedDepositLocations, "automated deposit location", "automated deposit locations");
+        Correlate(osmAutomatedDepositLoactions, listedDepositKiosks, "deposit kiosk", "deposit kiosks");
         Correlate(osmDepositAutomats, listedDepositAutomats, "deposit automat", "deposit automats");
         Correlate(osmManualDepositLoactions, listedManualDepositLocations, "manual deposit location", "manual deposit locations");
         
@@ -81,7 +81,7 @@ public class BottleDepositPointsAnalyzer : Analyzer
             Correlator<TItem> dataComparer = new Correlator<TItem>(
                 osmPoints,
                 dataPoints,
-                new MatchDistanceParamater(50), // most data is like 50 meters away
+                new MatchDistanceParamater(75), // often data points to shop instead of kiosk
                 new MatchFarDistanceParamater(150), // some are really far from where the data says they ought to be
                 new MatchExtraDistanceParamater(MatchStrength.Strong, 500), // allow really far for exact matches
                 new DataItemLabelsParamater(labelSingular, labelPlural),
@@ -90,6 +90,7 @@ public class BottleDepositPointsAnalyzer : Analyzer
                 new MatchCallbackParameter<DepositPoint>(GetMatchStrength)
             );
 
+            // todo: compare shop names too or maybe even extract it from Correlate and make strength function per item type
             [Pure]
             MatchStrength GetMatchStrength(DepositPoint point, OsmElement element)
             {

--- a/Osmalyzer/Analyzers/BottleDepositPointsAnalyzer.cs
+++ b/Osmalyzer/Analyzers/BottleDepositPointsAnalyzer.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+
+namespace Osmalyzer;
+
+[UsedImplicitly]
+public class BottleDepositPointsAnalyzer : Analyzer
+{
+    public override string Name => "Bottle Deposit Points";
+
+    public override string Description => "This report checks that all bottle deposit points are found on the map." + Environment.NewLine +
+                                          "Note that deposit points website may have errors, mainly large offsets, but also missing or incorrect locations.";
+
+    public override AnalyzerGroup Group => AnalyzerGroups.Misc;
+
+
+    public override List<Type> GetRequiredDataTypes() => new List<Type>()
+    {
+        typeof(OsmAnalysisData),
+        typeof(DepositPointsAnalysisData)
+    };
+
+
+    public override void Run(IReadOnlyList<AnalysisData> datas, Report report)
+    {
+        // Load OSM data
+
+        OsmAnalysisData osmData = datas.OfType<OsmAnalysisData>().First();
+
+        OsmMasterData osmMasterData = osmData.MasterData;
+
+        OsmDataExtract osmDepositPoints = osmMasterData.Filter(
+            new HasAnyValue("amenity", "vending_machine", "recycling"),
+            new CustomMatch(IsRelatedToDepositPoint)
+        );
+
+        [Pure]
+        bool IsRelatedToDepositPoint(OsmElement osmElement)
+        {
+            string? osmName =
+                osmElement.GetValue("brand") ??
+                osmElement.GetValue("name") ??
+                null;
+
+            return osmName != null && osmName.ToLower().Contains("Depozīta punkts".ToLower());
+        }
+
+        // Load Deposit point data
+
+        DepositPointsAnalysisData depositPointData = datas.OfType<DepositPointsAnalysisData>().First();
+
+        List<DepositPoint> listedDepositPoints = depositPointData.DepositPoints.ToList();
+
+        // Prepare data comparer/correlator
+
+        Correlator<DepositPoint> dataComparer = new Correlator<DepositPoint>(
+            osmDepositPoints,
+            listedDepositPoints,
+            new MatchDistanceParamater(100), // most data is like 50 meters away
+            new MatchFarDistanceParamater(300), // some are really far from where the data says they ought to be
+            new MatchExtraDistanceParamater(MatchStrength.Strong, 700), // allow really far for exact matches
+            new DataItemLabelsParamater("deposit point", "deposit points"),
+            new OsmElementPreviewValue("name", false),
+            new LoneElementAllowanceCallbackParameter(_ => true),
+            new MatchCallbackParameter<DepositPoint>(GetMatchStrength)
+        );
+
+        // todo: report closest potential (brand-untagged) shop when not matching anything?
+
+        [Pure]
+        MatchStrength GetMatchStrength(DepositPoint point, OsmElement element)
+        {
+            if (point.Address != null)
+                if (FuzzyAddressMatcher.Matches(element, point.Address))
+                    return MatchStrength.Strong;
+
+            return MatchStrength.Good;
+        }
+
+        // Parse and report primary matching and location correlation
+
+        dataComparer.Parse(
+            report,
+            new MatchedPairBatch(),
+            new MatchedLoneOsmBatch(true),
+            new UnmatchedItemBatch(),
+            new MatchedFarPairBatch(),
+            new UnmatchedOsmBatch()
+        );
+    }
+}

--- a/Osmalyzer/Analyzers/BottleDepositPointsAnalyzer.cs
+++ b/Osmalyzer/Analyzers/BottleDepositPointsAnalyzer.cs
@@ -8,10 +8,11 @@ namespace Osmalyzer;
 [UsedImplicitly]
 public class BottleDepositPointsAnalyzer : Analyzer
 {
-    public override string Name => "Bottle Deposit Points";
+    public override string Name => "Depozīta punkts";
 
     public override string Description => "This report checks that all bottle deposit points are found on the map." + Environment.NewLine +
-                                          "Note that deposit points website may have errors, mainly large offsets, but also missing or incorrect locations.";
+                                          "Note that deposit points website has errors: large offsets, missing locations " +
+                                          "and incorrect number of taromats in place.";
 
     public override AnalyzerGroup Group => AnalyzerGroups.Misc;
 
@@ -32,7 +33,12 @@ public class BottleDepositPointsAnalyzer : Analyzer
         OsmMasterData osmMasterData = osmData.MasterData;
 
         OsmDataExtract osmDepositPoints = osmMasterData.Filter(
-            new HasAnyValue("amenity", "vending_machine", "recycling"),
+            new HasAnyValue("amenity", "recycling"),
+            new CustomMatch(IsRelatedToDepositPoint)
+        );
+
+        OsmDataExtract osmDepositAutomats = osmMasterData.Filter(
+            new HasAnyValue("amenity", "vending_machine"),
             new CustomMatch(IsRelatedToDepositPoint)
         );
 
@@ -44,50 +50,58 @@ public class BottleDepositPointsAnalyzer : Analyzer
                 osmElement.GetValue("name") ??
                 null;
 
-            return osmName != null && osmName.ToLower().Contains("Depozīta punkts".ToLower());
+            return osmName != null 
+                && (osmName.ToLower().Contains("Depozīta".ToLower())
+                    || osmName.ToLower().Contains("Deposit".ToLower()));
         }
 
         // Load Deposit point data
 
         DepositPointsAnalysisData depositPointData = datas.OfType<DepositPointsAnalysisData>().First();
 
-        List<DepositPoint> listedDepositPoints = depositPointData.DepositPoints.ToList();
+        List<DepositPoint> listedDepositPoints = depositPointData.DepositPoints
+            .Where(_ => _.Mode != DepositPoint.DepositPointMode.Manual).ToList(); // Only automated for now
+        List<DepositPoint.DepositAutomat> listedDepositAutomats = depositPointData.DepositAutomats;
 
-        // Prepare data comparer/correlator
+        Correlate(osmDepositPoints, listedDepositPoints, "deposit point", "deposit points");
+        Correlate(osmDepositAutomats, listedDepositAutomats, "deposit automat", "deposit automats");
 
-        Correlator<DepositPoint> dataComparer = new Correlator<DepositPoint>(
-            osmDepositPoints,
-            listedDepositPoints,
-            new MatchDistanceParamater(100), // most data is like 50 meters away
-            new MatchFarDistanceParamater(300), // some are really far from where the data says they ought to be
-            new MatchExtraDistanceParamater(MatchStrength.Strong, 700), // allow really far for exact matches
-            new DataItemLabelsParamater("deposit point", "deposit points"),
-            new OsmElementPreviewValue("name", false),
-            new LoneElementAllowanceCallbackParameter(_ => true),
-            new MatchCallbackParameter<DepositPoint>(GetMatchStrength)
-        );
-
-        // todo: report closest potential (brand-untagged) shop when not matching anything?
-
-        [Pure]
-        MatchStrength GetMatchStrength(DepositPoint point, OsmElement element)
+        void Correlate<TItem>(OsmDataExtract osmPoints, List<TItem> dataPoints, string labelSingular, string labelPlural) where TItem : DepositPoint
         {
-            if (point.Address != null)
-                if (FuzzyAddressMatcher.Matches(element, point.Address))
-                    return MatchStrength.Strong;
+            // Prepare data comparer/correlator
 
-            return MatchStrength.Good;
+            Correlator<TItem> dataComparer = new Correlator<TItem>(
+                osmPoints,
+                dataPoints,
+                new MatchDistanceParamater(50), // most data is like 50 meters away
+                new MatchFarDistanceParamater(150), // some are really far from where the data says they ought to be
+                new MatchExtraDistanceParamater(MatchStrength.Strong, 500), // allow really far for exact matches
+                new DataItemLabelsParamater(labelSingular, labelPlural),
+                new OsmElementPreviewValue("name", false),
+                new LoneElementAllowanceCallbackParameter(_ => true),
+                new MatchCallbackParameter<DepositPoint>(GetMatchStrength)
+            );
+
+            [Pure]
+            MatchStrength GetMatchStrength(DepositPoint point, OsmElement element)
+            {
+                if (point.Address != null)
+                    if (FuzzyAddressMatcher.Matches(element, point.Address))
+                        return MatchStrength.Strong;
+
+                return MatchStrength.Good;
+            }
+
+            // Parse and report primary matching and location correlation
+
+            dataComparer.Parse(
+                report,
+                new MatchedPairBatch(),
+                new MatchedLoneOsmBatch(true),
+                new UnmatchedItemBatch(),
+                new MatchedFarPairBatch(),
+                new UnmatchedOsmBatch()
+            );
         }
-
-        // Parse and report primary matching and location correlation
-
-        dataComparer.Parse(
-            report,
-            new MatchedPairBatch(),
-            new MatchedLoneOsmBatch(true),
-            new UnmatchedItemBatch(),
-            new MatchedFarPairBatch(),
-            new UnmatchedOsmBatch()
-        );
     }
 }

--- a/Osmalyzer/Data/Data Items/DepositPoint.cs
+++ b/Osmalyzer/Data/Data Items/DepositPoint.cs
@@ -1,0 +1,37 @@
+﻿namespace Osmalyzer;
+
+public class DepositPoint : IDataItem
+{
+    public OsmCoord Coord { get; }
+    
+    public string Address { get; }
+
+    public string ShopName { get; }
+
+    public DepositPointMode Mode { get; }
+
+    public string DioId { get; }
+
+    public DepositPoint(string dioId, string address, string shopName, DepositPointMode mode, OsmCoord coord)
+    {
+        DioId = dioId;
+        Address = address;
+        ShopName = shopName;
+        Mode = mode;
+        Coord = coord;
+    }
+
+    public string ReportString()
+    {
+        return Mode.ToString() + " Deposit point " + DioId +
+           (ShopName != null ? " in shop '" + ShopName + "'" : "") + 
+           " (`" + Address + "`)";
+    }
+
+    public enum DepositPointMode
+    {
+        Automatic,
+        Manual,
+        BeramTaromats
+    }
+}

--- a/Osmalyzer/Data/Data Items/DepositPoint.cs
+++ b/Osmalyzer/Data/Data Items/DepositPoint.cs
@@ -8,7 +8,7 @@ public class DepositPoint : IDataItem
 
     public string ShopName { get; }
 
-    public DepositPointMode Mode { get; }
+    public DepositPointMode Mode { get; set; }
 
     public string DioId { get; }
 
@@ -19,6 +19,15 @@ public class DepositPoint : IDataItem
         ShopName = shopName;
         Mode = mode;
         Coord = coord;
+    }
+
+    public DepositPoint(DepositPoint point)
+    {
+        DioId = point.DioId;
+        Address = point.Address;
+        ShopName = point.ShopName;
+        Mode = point.Mode;
+        Coord = point.Coord;
     }
 
     public string ReportString()
@@ -33,5 +42,13 @@ public class DepositPoint : IDataItem
         Automatic,
         Manual,
         BeramTaromats
+    }
+
+    // It is here, just to differentiate at report level
+    public class DepositAutomat : DepositPoint
+    {
+        public DepositAutomat(DepositPoint point) : base(point)
+        {
+        }
     }
 }

--- a/Osmalyzer/Data/Data Items/DepositPoint.cs
+++ b/Osmalyzer/Data/Data Items/DepositPoint.cs
@@ -1,54 +1,79 @@
-﻿namespace Osmalyzer;
+﻿using System;
 
-public class DepositPoint : IDataItem
+namespace Osmalyzer;
+
+abstract public class DepositPoint : IDataItem
 {
+    public abstract string TypeString { get; }
+
     public OsmCoord Coord { get; }
     
     public string Address { get; }
 
     public string ShopName { get; }
 
-    public DepositPointMode Mode { get; set; }
-
     public string DioId { get; }
 
-    public DepositPoint(string dioId, string address, string shopName, DepositPointMode mode, OsmCoord coord)
+    public DepositPoint(string dioId, string address, string shopName, OsmCoord coord)
     {
         DioId = dioId;
         Address = address;
         ShopName = shopName;
-        Mode = mode;
         Coord = coord;
     }
 
-    public DepositPoint(DepositPoint point)
+    public virtual string ReportString()
     {
-        DioId = point.DioId;
-        Address = point.Address;
-        ShopName = point.ShopName;
-        Mode = point.Mode;
-        Coord = point.Coord;
+        return TypeString + " (" + DioId + ") " + 
+           (ShopName != null ? "in shop '" + ShopName + "' " : "") + 
+           "at (`" + Address + "`)";
     }
 
-    public string ReportString()
+}
+
+public enum TaromatMode
+{
+    Taromat,
+    BeramTaromat
+}
+
+public class DepositAutomat : DepositPoint
+{
+    public override string TypeString => "Taromat";
+
+    public TaromatMode Mode { get; }
+
+    public DepositAutomat(AutomatedDepositLocation point, TaromatMode mode)
+        : base(point.DioId, point.Address, point.ShopName, new OsmCoord(point.Coord.lat, point.Coord.lon))
     {
-        return Mode.ToString() + " Deposit point " + DioId +
-           (ShopName != null ? " in shop '" + ShopName + "'" : "") + 
-           " (`" + Address + "`)";
+        Mode = mode;
     }
 
-    public enum DepositPointMode
+    public override string ReportString()
     {
-        Automatic,
-        Manual,
-        BeramTaromats
-    }
-
-    // It is here, just to differentiate at report level
-    public class DepositAutomat : DepositPoint
-    {
-        public DepositAutomat(DepositPoint point) : base(point)
-        {
-        }
+        return Mode.ToString() + (ShopName != null ? "in shop '" + ShopName + "' " : "") + 
+           "at (`" + Address + "`)";
     }
 }
+
+public class AutomatedDepositLocation : DepositPoint
+{
+    public AutomatedDepositLocation(string dioId, string address, string shopName, OsmCoord coord)
+        : base(dioId, address, shopName, coord)
+    {
+    }
+
+    public override string TypeString => "Automated redemption location";
+}
+
+public class ManualDepositLocation : DepositPoint
+{
+    public override string TypeString => "Manual redemption location";
+    
+    public ManualDepositLocation(string dioId, string address, string shopName, OsmCoord coord)
+        : base(dioId, address, shopName, coord)
+    {
+    }
+
+}
+

--- a/Osmalyzer/Data/DepositPointsAnalysisData.cs
+++ b/Osmalyzer/Data/DepositPointsAnalysisData.cs
@@ -21,15 +21,18 @@ public class DepositPointsAnalysisData : AnalysisData, IUndatedAnalysisData
 
     public string DataFileName => Path.Combine(CacheBasePath, DataFileIdentifier + @".json");
 
-
+    // List of Depozita punkts. Might be standalone building, amenity inside shop or shop itself, that accepts bottles
     public List<DepositPoint> DepositPoints { get; private set; } = null!; // only null before prepared
+
+    // List of automats, that accept bottles.
+    public List<DepositPoint.DepositAutomat> DepositAutomats { get; private set; } = null!; // only null before prepared
 
 
     protected override void Download()
     {
         // list at https://depozitapunkts.lv/lv#kur-atgriezt
         // query to get JSON data at GET https://projects.kartes.lv/dio_api/
-    
+
         WebsiteDownloadHelper.Download(
             "https://projects.kartes.lv/dio_api/",
             DataFileName
@@ -39,6 +42,7 @@ public class DepositPointsAnalysisData : AnalysisData, IUndatedAnalysisData
     protected override void DoPrepare()
     {
         DepositPoints = new List<DepositPoint>();
+        DepositAutomats = new List<DepositPoint.DepositAutomat>();
 
         string source = File.ReadAllText(DataFileName);
 
@@ -46,9 +50,6 @@ public class DepositPointsAnalysisData : AnalysisData, IUndatedAnalysisData
             source,
             @"\{""type"":""Feature"",""properties"":\{(?<properties>[^{}]*)\},""geometry"":\{(?<geometry>[^{}]*)\}[^{}]*\}" //more magic regexes
         );
-
-//@"\{(?:""id"":\d+,)?""Adrese"":""(?<address>(?:\\""|[^""])*)"",""Datums"":(?:null|""(?:\\""|[^""])*""),\s*""uni_id"":""(?<id>[^""]+)"",""reitings"":(?:null|\d|""[^""]*""),""Shop_name"":(?:null|""(?<shop>(?:\\""|[^""])*)""),""AutoManual"":""(?<mode>[ABMabm])[^""]*"",""taromata_tips"":(?:null|""(?<size>(?:\\""|[^""])*)""),""Planota_metode"":(?:null|""(?:\\""|[^""])*"")(?:,""object_gauja_id"":[^}]*)?"
-
 
         if (matches.Count == 0)
             throw new Exception("Did not match any items on webpage");
@@ -61,21 +62,61 @@ public class DepositPointsAnalysisData : AnalysisData, IUndatedAnalysisData
             string dioId = Regex.Unescape(Regex.Match(properties, @"""uni_id"":""([^""]+)""").Groups[1].ToString());
             string address = Regex.Unescape(Regex.Match(properties, @"""Adrese"":""((?:\\""|[^""])*)""").Groups[1].ToString());
             string shopName = Regex.Unescape(Regex.Match(properties, @"""Shop_name"":""((?:\\""|[^""])*)""").Groups[1].ToString());
+            string numberOfTaromats = Regex.Unescape(Regex.Match(properties, @"""taromata_tips"":""((?:\\""|[^""])*)""").Groups[1].ToString()).ToLower();
             DepositPoint.DepositPointMode mode = ModeStringToType(Regex.Match(properties, @"""AutoManual"":""([ABMabm])(?:utomat[^""]*)?""").Groups[1].ToString());
-            
+
             Match geometryMatch = Regex.Match(geometry, @"""coordinates"":\[(?<long>\d+\.\d+),(?<lat>\d+\.\d+)\]");
             double lat = double.Parse(Regex.Unescape(geometryMatch.Groups["lat"].ToString()), CultureInfo.InvariantCulture);
             double lon = double.Parse(Regex.Unescape(geometryMatch.Groups["long"].ToString()), CultureInfo.InvariantCulture);
 
-            DepositPoints.Add(
-                new DepositPoint(
+
+            DepositPoint point = new DepositPoint(
                     dioId,
                     address,
                     shopName,
                     mode,
                     new OsmCoord(lat, lon)
-                )
-            );
+                );
+
+            DepositPoints.Add(point);
+            
+            // if deposit point is automated and info about number of automats provided, add automats into a separate list
+            if (point.Mode != DepositPoint.DepositPointMode.Manual
+                    && !numberOfTaromats.Contains("manuālā")  // because data is inconsistent
+                    && !string.IsNullOrWhiteSpace(numberOfTaromats))
+            {
+                MatchCollection matchedTaromats = Regex.Matches(
+                    numberOfTaromats,
+                    @"(?:(?<a_num>\d+) )?(?:mazais|vidējais|liel(?:ais|ie)) (?<taromat>taromāt[si])|(?:(?<b_num>\d+) )?(?<beram>beramtaromāt[si])"
+                );
+
+                if (matchedTaromats.Count == 0)
+                    throw new Exception("Didn't recognise number of taromats: '" + numberOfTaromats + "'");
+
+                foreach (Match matchedTaromat in matchedTaromats)
+                {
+                    var taromat = new DepositPoint.DepositAutomat(point);
+                    
+                    if (!string.IsNullOrEmpty(matchedTaromat.Groups["beram"]?.Value))
+                    {
+                        int number = int.TryParse(matchedTaromat.Groups["b_num"]?.Value, out int b_num) ? b_num : 1;
+                        taromat.Mode = DepositPoint.DepositPointMode.BeramTaromats;
+                        for (int i = 0; i < number; i++) 
+                        {
+                            DepositAutomats.Add(taromat);
+                        }
+                    }
+                    else if (!string.IsNullOrEmpty(matchedTaromat.Groups["taromat"]?.Value))
+                    {
+                        int number = int.TryParse(matchedTaromat.Groups["a_num"]?.Value, out int a_num) ? a_num : 1;
+                        taromat.Mode = DepositPoint.DepositPointMode.Automatic;
+                        for (int i = 0; i < number; i++) 
+                        {
+                            DepositAutomats.Add(taromat);
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -87,7 +128,7 @@ public class DepositPointsAnalysisData : AnalysisData, IUndatedAnalysisData
             "A" => DepositPoint.DepositPointMode.Automatic,
             "M" => DepositPoint.DepositPointMode.Manual,
             "B" => DepositPoint.DepositPointMode.BeramTaromats,
-            _   => throw new NotImplementedException()
+            _ => throw new NotImplementedException()
         };
     }
 }

--- a/Osmalyzer/Data/DepositPointsAnalysisData.cs
+++ b/Osmalyzer/Data/DepositPointsAnalysisData.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using JetBrains.Annotations;
+
+namespace Osmalyzer;
+
+[UsedImplicitly]
+public class DepositPointsAnalysisData : AnalysisData, IUndatedAnalysisData
+{
+    public override string Name => "Deposit points";
+
+    public override string ReportWebLink => @"https://depozitapunkts.lv/lv#kur-atgriezt";
+
+    public override bool NeedsPreparation => true;
+
+
+    protected override string DataFileIdentifier => "deposit-points";
+
+    public string DataFileName => Path.Combine(CacheBasePath, DataFileIdentifier + @".json");
+
+
+    public List<DepositPoint> DepositPoints { get; private set; } = null!; // only null before prepared
+
+
+    protected override void Download()
+    {
+        // list at https://depozitapunkts.lv/lv#kur-atgriezt
+        // query to get JSON data at GET https://projects.kartes.lv/dio_api/
+    
+        WebsiteDownloadHelper.Download(
+            "https://projects.kartes.lv/dio_api/",
+            DataFileName
+        );
+    }
+
+    protected override void DoPrepare()
+    {
+        DepositPoints = new List<DepositPoint>();
+
+        string source = File.ReadAllText(DataFileName);
+
+        MatchCollection matches = Regex.Matches(
+            source,
+            @"\{""type"":""Feature"",""properties"":\{(?:""id"":\d+,)?""Adrese"":""(?<address>(?:\\""|[^""])*)"",""Datums"":(?:null|""(?:\\""|[^""])*""),\s*""uni_id"":""(?<id>[^""]+)"",""reitings"":(?:null|\d|""[^""]*""),""Shop_name"":(?:null|""(?<shop>(?:\\""|[^""])*)""),""AutoManual"":""(?<mode>[ABMabm])[^""]*"",""taromata_tips"":(?:null|""(?<size>(?:\\""|[^""])*)""),""Planota_metode"":(?:null|""(?:\\""|[^""])*"")(?:,""object_gauja_id"":[^}]*)?\},""geometry"":\{""type"":""Point"",""coordinates"":\[(?<long>\d+\.\d+),(?<lat>\d+\.\d+)\]\},""id"":\d+\}"
+        );
+
+        if (matches.Count == 0)
+            throw new Exception("Did not match any items on webpage");
+
+        foreach (Match match in matches)
+        {
+            string dioId = Regex.Unescape(match.Groups["id"].ToString());
+            string address = Regex.Unescape(match.Groups["address"].ToString());
+            string shopName = Regex.Unescape(match.Groups["shop"].ToString());
+
+            DepositPoint.DepositPointMode mode = ModeStringToType(match.Groups["mode"].ToString());
+            double lat = double.Parse(Regex.Unescape(match.Groups["lat"].ToString()));
+            double lon = double.Parse(Regex.Unescape(match.Groups["long"].ToString()));
+
+            DepositPoints.Add(
+                new DepositPoint(
+                    dioId,
+                    address,
+                    shopName,
+                    mode,
+                    new OsmCoord(lat, lon)
+                )
+            );
+        }
+    }
+
+    [Pure]
+    private static DepositPoint.DepositPointMode ModeStringToType(string s)
+    {
+        return s.ToUpper() switch
+        {
+            "A" => DepositPoint.DepositPointMode.Automatic,
+            "M" => DepositPoint.DepositPointMode.Manual,
+            "B" => DepositPoint.DepositPointMode.BeramTaromats,
+            _   => throw new NotImplementedException()
+        };
+    }
+}

--- a/Osmalyzer/Runner.cs
+++ b/Osmalyzer/Runner.cs
@@ -60,7 +60,8 @@ public static class Runner
             // new DoubleMappedFeaturesAnalyzer(),
             // new CrossingConsistencyAnalyzer(),
             // new StreetTaggingContinuationAnalyzer(),
-            new PostCodeAnalyzer()
+            // new PostCodeAnalyzer(),
+            new BottleDepositPointsAnalyzer()
         };
 #endif
 


### PR DESCRIPTION
Proposed solution for #21

Introduced changes: report Depozīta punkts added to Misc category.
Three maps there:
- deposit kiosks - standalone kiosks for bottle redemption. Data doesn't contain indication what is and what is not a kiosk, so there is a bit of guess work there. Currently, locations only with big taromats and not in Lidls, considered kiosks. From OSM side locations identified by `amenity=recycling` and either name or brand containing `Depozīta` or `Deposit`.
- deposit automats - taromats for bottle redemption, both in kiosks and shops. Generated from data item's `taromata_tips` field. From OSM: `amenity=vending_machine` and `vending=bottle_return`.
- manual deposit locations - shops that accept bottle at counters. None are mapped so far (AFAIK), so a bit of a shot into the dark. Assumed expected tagging `shop=*`+`recycling:cans=yes`+`recycling:glass_bottles=yes``recycling:glass_bottles=yes`