### PR TITLE
Added OSM element tags to popup

### DIFF
--- a/Core/Primitives/OsmElement.cs
+++ b/Core/Primitives/OsmElement.cs
@@ -34,7 +34,22 @@ public abstract class OsmElement : IChunkerItem
     [PublicAPI]
     public IReadOnlyList<OsmRelationMember>? Relations => relations?.AsReadOnly();
 
-    
+    [PublicAPI]
+    public string getTags()
+    {
+        string s = "";
+
+        if (_tags == null)
+            return s;
+
+        foreach( var tag in _tags)
+        {
+            s += tag.Key + "=" + tag.Value + Environment.NewLine;
+        }
+        return s;
+    }
+
+   
     public (double x, double y) ChunkCoord => GetAverageCoord().ToCartesian();
 
 

--- a/Osmalyzer/Analyzers/Correlator/Correlator.cs
+++ b/Osmalyzer/Analyzers/Correlator/Correlator.cs
@@ -281,7 +281,7 @@ public class Correlator<T> where T : IDataItem
                         new MapPointReportEntry(
                             osmElement.GetAverageCoord(),
                             "No " + dataItemLabelSingular + " expected in " + unmatchDistance + " m range of OSM element " +
-                            OsmElementReportText(osmElement),
+                            OsmElementReportText(osmElement) + OsmElementTagsBlock(osmElement),
                             MapPointStyle.CorrelatorOsmUnmatched
                         )
                     );
@@ -314,7 +314,7 @@ public class Correlator<T> where T : IDataItem
                             match.Item.ReportString() + " " + 
                             MatchStrengthLabel(match.MatchStrength) + " OSM element " +
                             OsmElementReportText(match.Element) +
-                            " at " + match.Distance.ToString("F0") + " m",
+                            " at " + match.Distance.ToString("F0") + " m" + OsmElementTagsBlock(match.Element),
                             MapPointStyle.CorrelatorPairMatched
                         )
                     );
@@ -330,7 +330,7 @@ public class Correlator<T> where T : IDataItem
                                 " at " + match.Item.Coord.OsmUrl + ", " +
                                 " instead matched " +
                                 OsmElementReportText(match.Element) +
-                                " at " + match.Distance.ToString("F0") + " m",
+                                " at " + match.Distance.ToString("F0") + " m" + OsmElementTagsBlock(match.Element),
                                 MapPointStyle.CorrelatorPairMatchedOffsetOrigin
                             )
                         );
@@ -364,7 +364,7 @@ public class Correlator<T> where T : IDataItem
                             match.Item.ReportString() + " " + 
                             MatchStrengthLabel(match.MatchStrength) + " OSM element " +
                             OsmElementReportText(match.Element) +
-                            " but it's far away at " + match.Distance.ToString("F0") + " m",
+                            " but it's far away at " + match.Distance.ToString("F0") + " m" + OsmElementTagsBlock(match.Element),
                             MapPointStyle.CorrelatorPairMatchedFar
                         )
                     );
@@ -378,7 +378,7 @@ public class Correlator<T> where T : IDataItem
                             " at " + match.Item.Coord.OsmUrl + ", " +
                             " but matched " +
                             OsmElementReportText(match.Element) +
-                            " at " + match.Distance.ToString("F0") + " m",
+                            " at " + match.Distance.ToString("F0") + " m" + OsmElementTagsBlock(match.Element),
                             MapPointStyle.CorrelatorPairMatchedFarOrigin
                         )
                     );
@@ -405,7 +405,7 @@ public class Correlator<T> where T : IDataItem
                             osmElement.GetAverageCoord(),
                             "Matched OSM element " +
                             OsmElementReportText(osmElement) +
-                            " by itself",
+                            " by itself" + OsmElementTagsBlock(osmElement),
                             reportMatchedLoneOsmAsProblem ? MapPointStyle.CorrelatorLoneOsmUnmatched : MapPointStyle.CorrelatorLoneOsmMatched
                         )
                     );
@@ -515,6 +515,13 @@ public class Correlator<T> where T : IDataItem
         }
     }
 
+    private string OsmElementTagsBlock(OsmElement osmElement)
+    {
+        string tags = osmElement.getTags();
+
+        return tags != "" ? Environment.NewLine + "```" + tags + "```" : tags;
+
+    }
 
     private class Match
     {

--- a/Osmalyzer/Reporting/HtmlFileReportWriter.cs
+++ b/Osmalyzer/Reporting/HtmlFileReportWriter.cs
@@ -269,7 +269,8 @@ public class HtmlFileReportWriter : ReportWriter
         line = Regex.Replace(line, @"(https://mantojums.lv/(\d+))", @"<a href=""$1"" target=""_blank"">#$2</a>");
 
         // Other syntax
-        
+        line = Regex.Replace(line, @"```([^`]+)```", @"<pre class=""osm-tag""><code>$1</code></pre>");
+
         line = Regex.Replace(line, @"`([^`]+)`", @"<code class=""osm-tag"">$1</code>");
 
         line = line.Replace(Environment.NewLine, "<br>");


### PR DESCRIPTION
Solution for #11 

Don't think it bloats anything too much, but admit that have not checked all analyzers.

Additionally, this only applied to results of `Correlator`, so `Analyzer`s that don't use it (`HighwaySeasonalSpeedsAnalyzer`, for example) are not affected.