### PR TITLE
Check transliteration for English

### DIFF
--- a/Osmalyzer/Data/Misc Data Fetchers/OsmNamesAnalysisData.cs
+++ b/Osmalyzer/Data/Misc Data Fetchers/OsmNamesAnalysisData.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Osmalyzer;
+
+[UsedImplicitly]
+public class OsmNamesAnalysisData : AnalysisData
+{
+    public override string Name => "Names for OSM objects";
+
+    public override string? ReportWebLink => null;
+    
+    public override bool NeedsPreparation => false;
+    
+    protected override string DataFileIdentifier => "";
+
+    private readonly string[] locales = new string[] { "ru", "en" };
+
+    public Dictionary<string, Dictionary<string, List<string>>> Names { get; private set; } = null!; // only null until downloaded
+
+
+    protected override void Download()
+    {
+        Names = new Dictionary<string, Dictionary<string, List<string>>>();
+        
+        string dataFileName = @"data/object names.tsv";
+
+        if (!File.Exists(dataFileName))
+            dataFileName = @"../../../../" + dataFileName; // "exit" Osmalyzer\bin\Debug\net_.0\ folder and grab it from root data\
+            
+        string[] lines = File.ReadAllLines(dataFileName, Encoding.UTF8);
+
+        foreach (string line in lines)
+        {
+            if (!string.IsNullOrWhiteSpace(line) && !line.StartsWith("//"))
+            {
+                string[] splits = line.Split('\t');
+                
+                if (splits.Length != locales.Length + 1)
+                    throw new Exception("Incorrect number of locales in 'object names.tsv' file in line: " + line);
+                
+                var variants = new Dictionary<string, List<string>>();
+                for (int i = 0; i < locales.Length; i++)
+                {
+                    variants.Add(locales[i], splits[i+1].Split(';').ToList());
+                }
+                Names.Add(splits[0], variants);
+            }
+        }
+    }
+
+    protected override void DoPrepare()
+    {
+        // Not doing preparation
+        throw new Exception();
+    }
+}

--- a/data/object names.tsv
+++ b/data/object names.tsv
@@ -1,0 +1,14 @@
+//latvian   russian english
+// if mutiple values needed - separate by ;
+iela	улица;ул.	street;st.
+bulvāris	бульвар	boulevard
+ceļš	дорога	road
+gatve	гатве;проспект	gatve
+šoseja	шоссе	highway
+tilts	мост	bridge
+dambis	дамбис;дамба	dam
+aleja	аллея	alley
+apvedceļš	окружная дорога	bypass road
+laukums	площадь	square
+prospekts	проспект	avenue
+pārvads	переезд	crossing

--- a/data/object names.tsv
+++ b/data/object names.tsv
@@ -8,7 +8,7 @@ gatve	гатве;проспект	gatve
 tilts	мост	bridge
 dambis	дамбис;дамба	dam
 aleja	аллея	alley
-apvedceļš	окружная дорога	bypass road
+apvedceļš	окружная дорога	bypass
 laukums	площадь	square
 prospekts	проспект	avenue
 pārvads	переезд	crossing


### PR DESCRIPTION
Extracted names of nomenclature items into a separate tsv data file. Added multiple translations (like `iela` -> `улица` or `ул.`)
Added check for English transliteration.
Added list of encountered locales, that were not checked.

Might need addressing:
- Transliteration check report for bot Russian and English is dumped into one list. I think it might be useful to separate them, but I can fully work out how to do it properly.
- Check for English uses same approach with word distance. For now all letters treated as different. Added weights to allow switches between garumzime and not, but not sure how valid that is, so commented that out for now.

