### PR TITLE
Translit ru exceptions

### DIFF
--- a/Osmalyzer/Analyzers/Misc Analyzers/ImproperTranslationAnalyzer.cs
+++ b/Osmalyzer/Analyzers/Misc Analyzers/ImproperTranslationAnalyzer.cs
@@ -333,7 +333,7 @@ public class ImproperTranslationAnalyzer : Analyzer
 
         double distance = l.Distance(actual, expectedLower);
 
-        return distance <= 2.0 ? new GoodEnoughMatch(expectedOriginal) : new NotAMatch(expectedOriginal);
+        return distance <= 0.5 ? new GoodEnoughMatch(expectedOriginal) : new NotAMatch(expectedOriginal);
     }
 
     [Pure]

--- a/Osmalyzer/Analyzers/Misc Analyzers/ImproperTranslationAnalyzer.cs
+++ b/Osmalyzer/Analyzers/Misc Analyzers/ImproperTranslationAnalyzer.cs
@@ -502,6 +502,8 @@ public class ImproperTranslationAnalyzer : Analyzer
                 if (c1 == 'е' && c2 == 'ё') return 0.5;
                 if (c1 == 'и' && c2 == 'й') return 0.5;
                 if (c1 == 'ш' && c2 == 'щ') return 0.5;
+                if (c1 == 'х' && c2 == 'г') return 0.5;
+                if (c1 == 'а' && c2 == 'я') return 0.5;
 
                 return 1.0;
             }

--- a/Osmalyzer/Transliterator.cs
+++ b/Osmalyzer/Transliterator.cs
@@ -19,6 +19,10 @@ public static class Transliterator
         name = Regex.Replace(name, @"ļ(?![euioaēūīōāļ])", "ль");
         name = Regex.Replace(name, @"ģ(?![euioaēūīōāģ])", "гь");
         
+        // Эйзенштейна not Эизенштейна for Eizenšteina - but only at the start of word
+        name = Regex.Replace(name, @"\b[EĒ]i", "Эй");
+        name = Regex.Replace(name, @"\b[eē]i", "эй");
+        
         // Элизабетес not Елизабетес for Elizabetes - but only at the start of word
         name = Regex.Replace(name, @"\b[EĒ]", "Э");
         name = Regex.Replace(name, @"\b[eē]", "э");

--- a/Osmalyzer/Transliterator.cs
+++ b/Osmalyzer/Transliterator.cs
@@ -40,7 +40,7 @@ public static class Transliterator
         // Екабпилс not Йекабпилс for Jēkabpils
         name = ReplaceWithPreserveCase(name, "je", "е");
         name = ReplaceWithPreserveCase(name, "jē", "е");
-        
+
         // Кришьяня not Кришяня for Krišjāņa
         name = ReplaceWithPreserveCase(name, "šja", "шья");
         name = ReplaceWithPreserveCase(name, "šjā", "шья");
@@ -59,7 +59,6 @@ public static class Transliterator
         // Гравю not Гравйу for Grāvju
         name = ReplaceWithPreserveCase(name, "ju", "ю");
         name = ReplaceWithPreserveCase(name, "jū", "ю");
-        name = ReplaceWithPreserveCase(name, "pju", "пю");
 
         // Гипократа not Хипократа for Hipokrāta
         name = ReplaceWithPreserveCase(name, "hi", "ги");

--- a/Osmalyzer/Transliterator.cs
+++ b/Osmalyzer/Transliterator.cs
@@ -35,6 +35,10 @@ public static class Transliterator
         name = ReplaceWithPreserveCase(name, "je", "е");
         name = ReplaceWithPreserveCase(name, "jē", "е");
         
+        // Кришьяня not Кришяня for Krišjāņa
+        name = ReplaceWithPreserveCase(name, "šja", "шья");
+        name = ReplaceWithPreserveCase(name, "šjā", "шья");
+        
         // Стацияс not Стацийас for Stacijas
         name = ReplaceWithPreserveCase(name, "ja", "я");
         name = ReplaceWithPreserveCase(name, "jā", "я");
@@ -53,10 +57,6 @@ public static class Transliterator
 
         // Гипократа not Хипократа for Hipokrāta
         name = ReplaceWithPreserveCase(name, "hi", "ги");
-        
-        // Кришьяня not Кришяня for Krišjāņa
-        name = ReplaceWithPreserveCase(name, "šja", "шья");
-        name = ReplaceWithPreserveCase(name, "šjā", "шья");
         
         // Generic character to character conversion
         

--- a/Osmalyzer/Transliterator.cs
+++ b/Osmalyzer/Transliterator.cs
@@ -12,6 +12,12 @@ public static class Transliterator
         
         // Numbers don't have period
         name = Regex.Replace(name, @"(\d+).", "$1");
+
+        // Replace soft consonant followed by another consonant with soft sign
+        name = Regex.Replace(name, @"ņ(?![euioaēūīōāņ])", "нь");
+        name = Regex.Replace(name, @"ķ(?![euioaēūīōāķ])", "кь");
+        name = Regex.Replace(name, @"ļ(?![euioaēūīōāļ])", "ль");
+        name = Regex.Replace(name, @"ģ(?![euioaēūīōāģ])", "гь");
         
         // Элизабетес not Елизабетес for Elizabetes - but only at the start of word
         name = Regex.Replace(name, @"\b[EĒ]", "Э");


### PR DESCRIPTION
A bunch of minor changes to ru transliteration checker:
- Lowered weigh of difference between pairs `х/г` and `а/я`
- Made `Эй` an expected transliteration for `Ei` in the beginning of word
- Moved check for `šja/ā` to actually work
- Added soft sign between soft consonant followed by another consonant (other then the same one, like `ņņ`)

Additionally, lowered "good enough" threshold to 0.5: I'm working my way through transliterations, and I hope to address most of them that actually differ in at least a letter.