### PR TITLE
Lidl, Unisend and misc

### DIFF
--- a/Osmalyzer/Analyzers/Parcel Lockers/UnisendParcelLockerAnalyzer.cs
+++ b/Osmalyzer/Analyzers/Parcel Lockers/UnisendParcelLockerAnalyzer.cs
@@ -1,0 +1,6 @@
+﻿namespace Osmalyzer;
+
+public class UnisendParcelLockerAnalyzer : ParcelLockerAnalyzer<UnisendParcelLockerAnalysisData>
+{
+    protected override string Operator => "Unisend";
+}

--- a/Osmalyzer/Analyzers/Shop Networks/LidlShopAnalyzer.cs
+++ b/Osmalyzer/Analyzers/Shop Networks/LidlShopAnalyzer.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace Osmalyzer;
+
+public class LidlShopAnalyzer : ShopAnalyzer<LidlShopsAnalysisData>
+{
+    protected override string ShopName => "Lidl";
+
+    protected override List<string> ShopOsmNames => new List<string>() { ShopName };
+}

--- a/Osmalyzer/Data/Parcel Lockers/UnisendParcelLockerAnalysisData.cs
+++ b/Osmalyzer/Data/Parcel Lockers/UnisendParcelLockerAnalysisData.cs
@@ -1,0 +1,97 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+
+namespace Osmalyzer;
+
+[UsedImplicitly]
+public class UnisendParcelLockerAnalysisData : ParcelLockerAnalysisData
+{
+    public override string Name => "Unisend Parcel Lockers";
+
+    public override string ReportWebLink => @"https://my.unisend.lv/map";
+
+    protected override string DataFileIdentifier => "parcel-lockers-unisend";
+
+    public string DataFileName => Path.Combine(CacheBasePath, DataFileIdentifier + @".json");
+
+
+    public override IEnumerable<ParcelLocker> ParcelLockers => _parcelLockers;
+
+
+    private List<ParcelLocker> _parcelLockers = null!; // only null until prepared
+
+
+    protected override void Download()
+    {
+        // list at https://my.unisend.lv/map
+        // query to get json data at https://api-esavitarna.post.lt/terminal/list?size=9999
+
+        WebsiteDownloadHelper.Download(
+            "https://api-esavitarna.post.lt/terminal/list?size=9999",
+            DataFileName
+        );
+    }
+
+    protected override void DoPrepare()
+    {
+        _parcelLockers = new List<ParcelLocker>();
+
+        string source = File.ReadAllText(DataFileName);
+
+        // Data structure: {"content":[  item, item, ...  ], ...}
+
+        // Expecting item to be:
+        // {
+        //     "active": true,
+        //     "id": "8560",
+        //     "countryCode": "LV",
+        //     "name": "ELVI",
+        //     "provider": "udrop",
+        //     "city": "Kuldīga",
+        //     "address": "Gravas iela 1",
+        //     "postalCode": "LV-3301",
+        //     "latitude": "56.973548",
+        //     "longitude": "21.957985",
+        //     "workingHours": "00:24 h",
+        //     "servicingHours": "I - V 10:00, VI 10:00",
+        //     "comment": "Paštomatas kairėje įvažiavimo į stovi parkavimo aikštelę pusėje.",
+        //     "multilingualComment": "The parcel locker is located on the parking, on the left side from main entrance.",
+        //     "boxes": [
+        //         "XLarge",
+        //         "Large",
+        //         "Medium",
+        //         "Small",
+        //         "XSmall"
+        //     ],
+        //     "created": "2024-04-24 08:30:07",
+        //     "updated": "2024-05-31 20:30:02"
+        //}
+
+        dynamic content = JsonConvert.DeserializeObject<dynamic>(source)!;
+
+        foreach (dynamic item in content.content)
+        {
+            string id = item.id;
+            string name = item.name;
+            string address = item.address;
+            double lat = double.Parse(item.latitude.ToString());
+            double lon = double.Parse(item.longitude.ToString());
+            string country = item.countryCode;
+            string provider = item.provider;
+
+            if (country == "LV")
+            {
+                _parcelLockers.Add(
+                    new ParcelLocker(
+                        provider == "cleveron" ? "Unisend" : provider,
+                        id,
+                        name,
+                        address,
+                        new OsmCoord(lat, lon)
+                    )
+                );
+            }
+        }
+    }
+}

--- a/Osmalyzer/Data/Shop List/LidlShopsAnalysisData.cs
+++ b/Osmalyzer/Data/Shop List/LidlShopsAnalysisData.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace Osmalyzer;
+
+[UsedImplicitly]
+public class LidlShopsAnalysisData : ShopListAnalysisData
+{
+    public override string Name => "Lidl Shops";
+
+    public override string ReportWebLink => @"https://klientu-serviss.lidl.lv/SelfServiceLV/s/article/Kurās-pilsētās-7-oktobrī-tiks-atvērti-Lidl-veikali";
+    //@"https://klientu-serviss.lidl.lv/SelfServiceLV/s/article/Kur%C4%81s-pils%C4%93t%C4%81s-7-oktobr%C4%AB-tiks-atv%C4%93rti-Lidl-veikali";
+
+    public override bool NeedsPreparation => true;
+
+
+    protected override string DataFileIdentifier => "shops-lidl";
+
+    public override IEnumerable<ShopData> Shops => _shops;
+    
+    private List<ShopData> _shops = null!; // only null until prepared
+
+
+    protected override void Download()
+    {
+        WebsiteBrowsingHelper.DownloadPage(
+            ReportWebLink, 
+            Path.Combine(CacheBasePath, DataFileIdentifier + @".html"),
+            true,
+            new WaitForElementOfClass("siteforceContentArea") // loads JS garbage first that loads the rest of the page     siteforceContentArea  article_content
+        );
+    }
+
+    protected override void DoPrepare()
+    {
+        string data = File.ReadAllText(Path.Combine(CacheBasePath, DataFileIdentifier + @".html"));
+
+        //<a target="_blank" href="https://goo.gl/maps/6acQANjGsGkFyqFD9">Anniņmuižas bulvārī 77</a>
+
+        _shops = new List<ShopData>();
+        
+        MatchCollection matches = Regex.Matches(data, @"<a target=""_blank"" href=""(https://(?:goo.gl/maps|maps.app.goo.gl)/[^""]+)"">(.+?)</a>");
+
+        if (matches.Count == 0)
+            throw new Exception("Did not find items on webpage");
+        
+        foreach (Match match in matches)
+        {
+            var url = WebsiteDownloadHelper.GetRedirectUrl(match.Groups[1].Value);
+            Match m = Regex.Match(url, @"!3d(\d+\.\d+)!4d(\d+\.\d+)");
+            OsmCoord coord = new OsmCoord(
+                double.Parse(m.Groups[1].Value),
+                double.Parse(m.Groups[2].Value)
+            );
+
+            ShopData sd = new ShopData(match.Groups[1].Value, match.Groups[2].Value, coord);
+
+            _shops.Add(sd);
+        }
+
+        var i = _shops.Count;
+    }
+}

--- a/Osmalyzer/Misc/Transliterator.cs
+++ b/Osmalyzer/Misc/Transliterator.cs
@@ -20,7 +20,7 @@ public static class Transliterator
         name = Regex.Replace(name, @"ģ(?![euioaēūīōāģ])", "гь");
 
         // For combinations consonant + j + vowel add a soft sign into transliteration, to emphasize presence of sound `j`
-        // Example: Кришьяня not Кришяня for Krišjāņa
+        // Example: Канепью not Канепю for Kaņepju
         name = Regex.Replace(name, @"(?<=[rtplkgfdscvbnmļķņčģ])(?=j[aeuioāēūīō])", "ь", RegexOptions.IgnoreCase);
         
         // Эйзенштейна not Эизенштейна for Eizenšteina - but only at the start of word
@@ -48,6 +48,10 @@ public static class Transliterator
         // Екабпилс not Йекабпилс for Jēkabpils
         name = ReplaceWithPreserveCase(name, "je", "е");
         name = ReplaceWithPreserveCase(name, "jē", "е");
+
+        // Кришьяня not Кришяня for Krišjāņa
+        name = ReplaceWithPreserveCase(name, "šja", "шья");
+        name = ReplaceWithPreserveCase(name, "šjā", "шья");
         
         // Стацияс not Стацийас for Stacijas
         name = ReplaceWithPreserveCase(name, "ja", "я");

--- a/Osmalyzer/Reporting/Report templates/main.html
+++ b/Osmalyzer/Reporting/Report templates/main.html
@@ -114,6 +114,7 @@
 
 </head>
 <body>
+    <a href="index.html">🏠Home</a>
 
 <!--BODY-->
 

--- a/Osmalyzer/Runner.cs
+++ b/Osmalyzer/Runner.cs
@@ -72,6 +72,7 @@ public static class Runner
             // new LatviaPostLockerAnalyzer(),
             // new LatviaPostMailBoxAnalyzer(),
             // new ImproperTranslationAnalyzer(),
+            // new LidlShopAnalyzer(),
             new SpellingAnalyzer()
         };
 #endif

--- a/Osmalyzer/Runner.cs
+++ b/Osmalyzer/Runner.cs
@@ -73,6 +73,7 @@ public static class Runner
             // new LatviaPostMailBoxAnalyzer(),
             // new ImproperTranslationAnalyzer(),
             // new LidlShopAnalyzer(),
+            // new UnisendParcelLockerAnalyzer(),
             new SpellingAnalyzer()
         };
 #endif

--- a/Osmalyzer/Web Stuff/WebsiteDownloadHelper.cs
+++ b/Osmalyzer/Web Stuff/WebsiteDownloadHelper.cs
@@ -69,4 +69,17 @@ public static class WebsiteDownloadHelper
             
         return lastModifedOffset.Value.UtcDateTime;
     }
+
+    
+    public static string GetRedirectUrl(string url)
+    {
+        var handler = new HttpClientHandler()
+            {
+                AllowAutoRedirect = false
+            };
+        using HttpClient client = new HttpClient(handler);
+        Uri uri = new Uri(url, UriKind.Absolute);
+        using HttpResponseMessage response = client.SendAsync(new HttpRequestMessage(HttpMethod.Head, uri)).Result;
+        return response.Headers.Location?.AbsolutePath ?? "";
+    }
 }


### PR DESCRIPTION
Added analyzer for Lidl shops #3.
Added analyzer for Unisend brand parcel lockers: both operated by Unisend themselves and uDrop, without check for correct operator in tags #7.
Fixed transliteration for `šja/šjā` broken earlier.
Added home button #40.