### PR TITLE
Translit improvements

### DIFF
--- a/Osmalyzer/Analyzers/Helpers/BoundaryHelper.cs
+++ b/Osmalyzer/Analyzers/Helpers/BoundaryHelper.cs
@@ -25,6 +25,14 @@ public static class BoundaryHelper
         return _rigaPolygon;
     }
 
+    [Pure]
+    public static OsmPolygon GetDaugavpilsPolygon(OsmMasterData osmData)
+    {
+        if (_rigaPolygon == null)
+            _rigaPolygon = GetAdminRelationPolygon(osmData, "6", "Daugavpils");
+        
+        return _rigaPolygon;
+    }
 
     [Pure]
     private static OsmPolygon GetAdminRelationPolygon(OsmMasterData osmData, string level, string name)

--- a/Osmalyzer/Analyzers/Helpers/FuzzyAddressMatcher.cs
+++ b/Osmalyzer/Analyzers/Helpers/FuzzyAddressMatcher.cs
@@ -5,6 +5,7 @@ namespace Osmalyzer;
 
 public static class FuzzyAddressMatcher
 {
+    // TODO: rewrite to use tsv file from data
     private static readonly string[] _suffixes = 
     {
         "iela",
@@ -18,7 +19,10 @@ public static class FuzzyAddressMatcher
         "apvedceļš",
         "laukums",
         "prospekts",
-        "pārvads"
+        "pārvads",
+        "līnija",
+        "šķērslīnija",
+        "krastmala",
     };
     // Note: ImproperTranslationAnalyzer is doing Russian translations, so add value there if adding here
     

--- a/Osmalyzer/Analyzers/Misc Analyzers/ImproperTranslationAnalyzer.cs
+++ b/Osmalyzer/Analyzers/Misc Analyzers/ImproperTranslationAnalyzer.cs
@@ -34,9 +34,12 @@ public class ImproperTranslationAnalyzer : Analyzer
 
         OsmMasterData osmMasterData = osmData.MasterData;
 
-        OsmDataExtract osmElements = osmMasterData.Filter(
+        OsmDataExtract osmHighwayElements = osmMasterData.Filter(
             new IsWay(),
-            new HasKey("highway"),
+            new OrMatch(
+                new HasKey("highway"),
+                new HasValue("route", "road")
+            ),
             new HasKey("name"),
             new HasKeyPrefixed("name:"),
             new InsidePolygon(BoundaryHelper.GetLatviaPolygon(osmData.MasterData), OsmPolygon.RelationInclusionCheck.Fuzzy)
@@ -58,7 +61,7 @@ public class ImproperTranslationAnalyzer : Analyzer
 
         // Parse
 
-        foreach (OsmElement element in osmElements.Elements)
+        foreach (OsmElement element in osmHighwayElements.Elements)
         {
             string name = element.GetValue("name")!;
 

--- a/Osmalyzer/Analyzers/Misc Analyzers/ImproperTranslationAnalyzer.cs
+++ b/Osmalyzer/Analyzers/Misc Analyzers/ImproperTranslationAnalyzer.cs
@@ -53,6 +53,7 @@ public class ImproperTranslationAnalyzer : Analyzer
             knownLanguages.ToDictionary(kl => kl, _ => new LanguageAnalysisResults());
         
         Dictionary<string, int> ignoredLanguages = new Dictionary<string, int>();
+        List<string> ignoredNames = new();
 
         // Parse
 
@@ -66,7 +67,10 @@ public class ImproperTranslationAnalyzer : Analyzer
 
             // todo: how many do we not know?
             if (lvNameRaw == null)
+            {
+                ignoredNames.Add(name);
                 continue; // we don't actually know how this name is constructed in Latvian
+            }
 
             // Other languages
 
@@ -310,6 +314,27 @@ public class ImproperTranslationAnalyzer : Analyzer
                 )
             );
         }
+
+
+        report.AddGroup(
+            GenericReportGroup.OtherNames, 
+            "Ignored names",
+            "List of items that were not checked, because their name was not recognized (for example streets that don't have recovnized translatable nomenclature)"
+        );
+
+        foreach (string n in ignoredNames.Distinct().Where(_ => !_.Contains("—")))
+        {
+            report.AddEntry(
+                GenericReportGroup.OtherNames,
+                new IssueReportEntry(
+                    "Name '" + n + "' was ignored. " 
+                    //number + " " + (number == 1 ? "element has" : "elements have") + " tag `name:" + language + "`",
+                    //new SortEntryDesc(number)
+                )
+            );
+        }
+        
+        
     }
 
 
@@ -553,7 +578,8 @@ public class ImproperTranslationAnalyzer : Analyzer
 
     private enum GenericReportGroup
     {
-        OtherLanguages
+        OtherLanguages,
+        OtherNames
         // Individual langauges will go to their own group
     }
 }

--- a/Osmalyzer/Analyzers/Misc Analyzers/ImproperTranslationAnalyzer.cs
+++ b/Osmalyzer/Analyzers/Misc Analyzers/ImproperTranslationAnalyzer.cs
@@ -61,13 +61,16 @@ public class ImproperTranslationAnalyzer : Analyzer
         );
         // place=*, boundary = administrative, railway = station
 
-        OsmDataExtract osmPlaceElements = osmMasterData.Filter(
-            new HasKey("place"),
-            new DoesntHaveAnyValue("place", "city"),
-            new HasKey("name"),
-            new HasKeyPrefixed("name:"),
-            new InsidePolygon(BoundaryHelper.GetLatviaPolygon(osmData.MasterData), OsmPolygon.RelationInclusionCheck.Fuzzy)
-        );
+        // Too much of (probably) false positives
+        // OsmDataExtract osmPlaceElements = osmMasterData.Filter(
+        //     new HasKey("place"),
+        //     new DoesntHaveAnyValue("place", "city"),
+        //     new HasKey("name"),
+        //     new HasKeyPrefixed("name:"),
+        //     // Exclude Daugavpils for the time being
+        //     //new CustomMatch(_ => !BoundaryHelper.GetDaugavpilsPolygon(osmData.MasterData).ContainsElement(_, OsmPolygon.RelationInclusionCheck.Fuzzy)),
+        //     new InsidePolygon(BoundaryHelper.GetLatviaPolygon(osmData.MasterData), OsmPolygon.RelationInclusionCheck.Fuzzy)
+        // );
         OsmDataExtract osmAdminBoundariesElements = osmMasterData.Filter(
             new IsWay(),
             new HasValue("boundary", "administrative"),
@@ -87,10 +90,10 @@ public class ImproperTranslationAnalyzer : Analyzer
 
         // Parse
 
-        method(osmHighwayElements.Elements, true, results, nameQualifiersData, ignoredNames, ignoredLanguages);
-        method(osmPlaceElements.Elements, false, results, nameQualifiersData, ignoredNames, ignoredLanguages);
-        method(osmAdminBoundariesElements.Elements, false, results, nameQualifiersData, ignoredNames, ignoredLanguages);
-        method(osmRwStationsElements.Elements, false, results, nameQualifiersData, ignoredNames, ignoredLanguages);
+        checkElementsTranliteration(osmHighwayElements.Elements, true, results, nameQualifiersData, ignoredNames, ignoredLanguages);
+        // checkElementsTranliteration(osmPlaceElements.Elements, false, results, nameQualifiersData, ignoredNames, ignoredLanguages);
+        checkElementsTranliteration(osmAdminBoundariesElements.Elements, false, results, nameQualifiersData, ignoredNames, ignoredLanguages);
+        checkElementsTranliteration(osmRwStationsElements.Elements, false, results, nameQualifiersData, ignoredNames, ignoredLanguages);
         
         // Report checked languages
 
@@ -184,7 +187,7 @@ public class ImproperTranslationAnalyzer : Analyzer
         
     }
 
-    private void method(
+    private void checkElementsTranliteration(
         IReadOnlyList<OsmElement> elements, 
         bool nomenclatureRequired,
         Dictionary<KnownLanguage, LanguageAnalysisResults> results,

--- a/Osmalyzer/Analyzers/Misc Analyzers/ImproperTranslationAnalyzer.cs
+++ b/Osmalyzer/Analyzers/Misc Analyzers/ImproperTranslationAnalyzer.cs
@@ -23,10 +23,25 @@ public class ImproperTranslationAnalyzer : Analyzer
         typeof(OsmAnalysisData),
         typeof(StreetNameQualifiersAnalysisData)
     };
+
+            // These are the languages we check and know about
+    private List<KnownLanguage> knownLanguages = new List<KnownLanguage>()
+    {
+        new KnownLanguage("Russian", "ru"),
+        new KnownLanguage("English", "en"),
+        new KnownLanguage("Latvian", "lv")
+    };
         
 
     public override void Run(IReadOnlyList<AnalysisData> datas, Report report)
     {
+        // Each language keeps its record of results
+        Dictionary<KnownLanguage, LanguageAnalysisResults> results =
+            knownLanguages.ToDictionary(kl => kl, _ => new LanguageAnalysisResults());
+        
+        Dictionary<string, int> ignoredLanguages = new Dictionary<string, int>();
+        List<string> ignoredNames = new List<string>();
+
         // Load OSM data
 
         OsmAnalysisData osmData = datas.OfType<OsmAnalysisData>().First();
@@ -44,160 +59,38 @@ public class ImproperTranslationAnalyzer : Analyzer
             new HasKeyPrefixed("name:"),
             new InsidePolygon(BoundaryHelper.GetLatviaPolygon(osmData.MasterData), OsmPolygon.RelationInclusionCheck.Fuzzy)
         );
+        // place=*, boundary = administrative, railway = station
 
-        // These are the languages we check and know about
-        List<KnownLanguage> knownLanguages = new List<KnownLanguage>()
-        {
-            new KnownLanguage("Russian", "ru"),
-            new KnownLanguage("English", "en")
-        };
+        OsmDataExtract osmPlaceElements = osmMasterData.Filter(
+            new HasKey("place"),
+            new DoesntHaveAnyValue("place", "city"),
+            new HasKey("name"),
+            new HasKeyPrefixed("name:"),
+            new InsidePolygon(BoundaryHelper.GetLatviaPolygon(osmData.MasterData), OsmPolygon.RelationInclusionCheck.Fuzzy)
+        );
+        OsmDataExtract osmAdminBoundariesElements = osmMasterData.Filter(
+            new IsWay(),
+            new HasValue("boundary", "administrative"),
+            new HasKey("name"),
+            // filter out cross border objects
+            new CustomMatch(_ => _.HasKey("name") && !Regex.Match(_.GetValue("name")!, @" [-—/] ").Success),
+            new HasKeyPrefixed("name:"),
+            new InsidePolygon(BoundaryHelper.GetLatviaPolygon(osmData.MasterData), OsmPolygon.RelationInclusionCheck.Fuzzy)
+        );
+        OsmDataExtract osmRwStationsElements = osmMasterData.Filter(
+            new HasValue("railway", "station"),
+            new HasKey("name"),
+            new HasKeyPrefixed("name:"),
+            new InsidePolygon(BoundaryHelper.GetLatviaPolygon(osmData.MasterData), OsmPolygon.RelationInclusionCheck.Fuzzy)
+        );
 
-        // Each language keeps its record of results
-        Dictionary<KnownLanguage, LanguageAnalysisResults> results =
-            knownLanguages.ToDictionary(kl => kl, _ => new LanguageAnalysisResults());
-        
-        Dictionary<string, int> ignoredLanguages = new Dictionary<string, int>();
-        List<string> ignoredNames = new();
 
         // Parse
 
-        foreach (OsmElement element in osmHighwayElements.Elements)
-        {
-            string name = element.GetValue("name")!;
-
-            // Main name
-
-            string? lvNameRaw = ExtractRawLatvianName(name, out string? latvianNameSuffix);
-
-            // todo: how many do we not know?
-            if (lvNameRaw == null)
-            {
-                ignoredNames.Add(name);
-                continue; // we don't actually know how this name is constructed in Latvian
-            }
-
-            // Other languages
-
-            List<(string, string)> nameXxs = element.GetPrefixedValues("name:")!;
-
-            foreach ((string key, string value) in nameXxs)
-            {
-                if (value == name) // may not be great, but not an error
-                    continue;
-                
-                List<Issue> issues = new List<Issue>();
-
-                string? language = ExtractLanguage(key);
-
-                if (language == null)
-                {
-                    // TODO: report bad language key
-                    continue;
-                }
-
-                if (language == "lv")
-                {
-                    // todo: check if mismatch?
-                    continue; // we assume we are by default in Latvian
-                }
-
-                KnownLanguage? knownLanguage = knownLanguages.FirstOrDefault(kl => kl.OsmSuffix == language);
-
-                if (knownLanguage != null)
-                {
-                    // We know about this language, so we can check the name
-                    
-                    // Collect new results into the language-specific container
-                    LanguageAnalysisResults languageResults = results[knownLanguage];
-
-                    switch (language)
-                    {
-                        case "ru":
-                        {
-                            // Figure out how the street should look like in Russian transliteration
-
-                            List<string> expectedRuPrefixes = nameQualifiersData.Names[latvianNameSuffix!][language];
-                            // It is acceptable for all object to be named as street (why?)
-                            expectedRuPrefixes = expectedRuPrefixes.Union(nameQualifiersData.Names["iela"][language]).ToList();
-
-                            List<string> expectedNames = new List<string>();
-
-                            string translit = Transliterator.TransliterateFromLvToRu(lvNameRaw);
-
-                            foreach (string expectedPrefix in expectedRuPrefixes)
-                            {
-                                if (Regex.Match(translit, @"\d\s*$").Success)
-                                {
-                                    // For names like 'Imantas 1. līnija' -> 'Имантас 1-я линия'
-                                    expectedNames.Add(translit + "-я " + expectedPrefix);
-                                    expectedNames.Add(translit + "-й " + expectedPrefix);
-                                }
-                                else 
-                                {
-                                    expectedNames.Add(expectedPrefix + " " + translit);
-                                    expectedNames.Add(translit + " " + expectedPrefix);
-                                }
-                            }
-
-                            // Match against current value
-                            checkTransliteration(value, expectedNames, name, languageResults, issues, knownLanguage, MatchBetweenFuzzyCyrillic);
-
-                            break;
-                        }
-                        case "en":
-                        {
-                            List<string> expectedEnPrefixes = nameQualifiersData.Names[latvianNameSuffix!][language];
-                            // It is acceptable for all object to be named as street (why?)
-                            expectedEnPrefixes = expectedEnPrefixes.Union(nameQualifiersData.Names["iela"][language]).ToList();
-
-                            List<string> expectedNames = new List<string>();
-
-                            // Handle names like '12th street' and '2nd Line'
-                            string translit = lvNameRaw;
-                            translit = Regex.Replace(translit, @"(?<!1)1\.\s*$", @"1st");
-                            translit = Regex.Replace(translit, @"(?<!1)2\.\s*$", @"2nd");
-                            translit = Regex.Replace(translit, @"(?<!1)3\.\s*$", @"3rd");
-                            translit = Regex.Replace(translit, @"(\d)\.\s*$", @"$1th");
-
-                            // Expect exact name with only translation for the nomenclature
-                            foreach (string expectedPrefix in expectedEnPrefixes)
-                            {
-                                expectedNames.Add(translit + " " + expectedPrefix);
-                            }
-
-                            checkTransliteration(value, expectedNames, name, languageResults, issues, knownLanguage, MatchBetweenExact);
-
-                            break;
-                        }
-                        
-                        default:
-                            throw new NotImplementedException();
-                    }
-
-                    // Did we find any issues for this element?
-
-                    if (issues.Count > 0)
-                    {
-                        // Any element(s) with this exact issue already?
-                        ProblemFeature? existing = languageResults.problemFeatures.FirstOrDefault(f => f.IssuesMatch(issues));
-
-                        // todo: dont add by distance too close
-
-                        if (existing != null)
-                            existing.Elements.Add(element); // issues are the same already
-                        else
-                            languageResults.problemFeatures.Add(new ProblemFeature(new List<OsmElement>() { element }, issues));
-                    }
-                }
-                else
-                {
-                    if (ignoredLanguages.ContainsKey(language))
-                        ignoredLanguages[language]++;
-                    else
-                        ignoredLanguages.Add(language, 1);
-                }
-            }
-        }
+        method(osmHighwayElements.Elements, true, results, nameQualifiersData, ignoredNames, ignoredLanguages);
+        method(osmPlaceElements.Elements, false, results, nameQualifiersData, ignoredNames, ignoredLanguages);
+        method(osmAdminBoundariesElements.Elements, false, results, nameQualifiersData, ignoredNames, ignoredLanguages);
+        method(osmRwStationsElements.Elements, false, results, nameQualifiersData, ignoredNames, ignoredLanguages);
         
         // Report checked languages
 
@@ -291,6 +184,156 @@ public class ImproperTranslationAnalyzer : Analyzer
         
     }
 
+    private void method(
+        IReadOnlyList<OsmElement> elements, 
+        bool nomenclatureRequired,
+        Dictionary<KnownLanguage, LanguageAnalysisResults> results,
+        StreetNameQualifiersAnalysisData nameQualifiersData,
+        List<string> ignoredNames,
+        Dictionary<string, int> ignoredLanguages
+    )
+    {
+        foreach (OsmElement element in elements)
+        {
+            string name = element.GetValue("name")!;
+
+            // Main name
+            bool isSuffixFound = ExtractNomenclature(name, nameQualifiersData.Names.Keys.ToList(), out string lvNameRaw, out string? latvianNameSuffix);
+            
+            if (nomenclatureRequired && !isSuffixFound)
+            {
+                ignoredNames.Add(name);
+                // we don't actually know how this name is constructed in Latvian
+                continue; 
+            }
+
+            // Other languages
+
+            List<(string, string)> nameXxs = element.GetPrefixedValues("name:")!;
+
+            foreach ((string key, string value) in nameXxs)
+            {                
+                List<Issue> issues = new List<Issue>();
+
+                string? language = ExtractLanguage(key);
+
+                if (language == null)
+                {
+                    // TODO: report bad language key
+                    continue;
+                }
+
+                KnownLanguage? knownLanguage = knownLanguages.FirstOrDefault(kl => kl.OsmSuffix == language);
+
+                if (knownLanguage != null)
+                {
+                    // We know about this language, so we can check the name
+                    
+                    // Collect new results into the language-specific container
+                    LanguageAnalysisResults languageResults = results[knownLanguage];
+
+                    switch (language)
+                    {
+                        case "lv":
+                        {
+                            // Expect exactly the same values as in name
+                            List<string> expectedNames = new List<string> {name};
+                            checkTransliteration(value, expectedNames, name, languageResults, issues, knownLanguage, MatchBetweenExact);
+                            break;
+                        }
+                        case "ru":
+                        {
+                            // Figure out how the street should look like in Russian transliteration
+
+                            List<string> expectedNames = new List<string>();
+
+                            string translit = Transliterator.TransliterateFromLvToRu(lvNameRaw);
+
+                            if (latvianNameSuffix != null)
+                            {
+                                List<string> expectedRuPrefixes = nameQualifiersData.Names[latvianNameSuffix!][language];
+
+                                foreach (string expectedPrefix in expectedRuPrefixes)
+                                {
+                                    if (Regex.Match(translit, @"\d\s*$").Success)
+                                    {
+                                        // For names like 'Imantas 1. līnija' -> 'Имантас 1-я линия'
+                                        expectedNames.Add(translit + "-я " + expectedPrefix);
+                                        expectedNames.Add(translit + "-й " + expectedPrefix);
+                                    }
+                                    else 
+                                    {
+                                        expectedNames.Add(expectedPrefix + " " + translit);
+                                        expectedNames.Add(translit + " " + expectedPrefix);
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                expectedNames.Add(translit);
+                            }
+
+                            // Match against current value
+                            checkTransliteration(value, expectedNames, name, languageResults, issues, knownLanguage, MatchBetweenFuzzyCyrillic);
+
+                            break;
+                        }
+                        case "en":
+                        {
+                            // Handle names like '12th street' and '2nd Line'
+                            string translit = Transliterator.TransliterateFromLvToEn(lvNameRaw);
+                            
+                            List<string> expectedNames = new List<string>();
+
+                            if (latvianNameSuffix != null)
+                            {
+                                List<string> expectedEnPrefixes = nameQualifiersData.Names[latvianNameSuffix!][language];
+
+                                // Expect exact name with only translation for the nomenclature
+                                foreach (string expectedPrefix in expectedEnPrefixes)
+                                {
+                                    expectedNames.Add(translit + " " + expectedPrefix);
+                                }
+                            }
+                            else
+                            {
+                                expectedNames.Add(translit);
+                            }
+                            checkTransliteration(value, expectedNames, name, languageResults, issues, knownLanguage, MatchBetweenExact);
+
+                            break;
+                        }
+                        
+                        default:
+                            throw new NotImplementedException();
+                    }
+
+                    // Did we find any issues for this element?
+
+                    if (issues.Count > 0)
+                    {
+                        // Any element(s) with this exact issue already?
+                        ProblemFeature? existing = languageResults.problemFeatures.FirstOrDefault(f => f.IssuesMatch(issues));
+
+                        // todo: dont add by distance too close
+
+                        if (existing != null)
+                            existing.Elements.Add(element); // issues are the same already
+                        else
+                            languageResults.problemFeatures.Add(new ProblemFeature(new List<OsmElement>() { element }, issues));
+                    }
+                }
+                else
+                {
+                    if (ignoredLanguages.ContainsKey(language))
+                        ignoredLanguages[language]++;
+                    else
+                        ignoredLanguages.Add(language, 1);
+                }
+            }
+        }
+    }
+
     [Pure]
     private static void checkTransliteration(
         string value, 
@@ -338,12 +381,20 @@ public class ImproperTranslationAnalyzer : Analyzer
     }
 
     [Pure]
-    private static string? ExtractRawLatvianName(string name, out string? suffix)
+    private static bool ExtractNomenclature(string name, List<string> nomenclature, out string rawName, out string? nomenclatureName)
     {
-        if (FuzzyAddressMatcher.EndsWithStreetNameSuffix(name, out suffix))
-            return name[..^(suffix!.Length + 1)]; // also grab the implied space 
-
-        return null;
+        foreach (string s in nomenclature)
+        {
+            if (name.EndsWith(" " + s))
+            {
+                nomenclatureName = s;
+                rawName = name[..^(s!.Length)].Trim();
+                return true;
+            }
+        }
+        rawName = name;
+        nomenclatureName = null;
+        return false;
     }
 
     [Pure]

--- a/Osmalyzer/Misc/Transliterator.cs
+++ b/Osmalyzer/Misc/Transliterator.cs
@@ -82,6 +82,9 @@ public static class Transliterator
             translit += newC;
         }
 
+        // Post processing 
+        translit = translit.Replace("ьйо","ё");
+
         return translit;
     }
 

--- a/Osmalyzer/Misc/Transliterator.cs
+++ b/Osmalyzer/Misc/Transliterator.cs
@@ -86,6 +86,17 @@ public static class Transliterator
     }
 
     
+    [Pure]
+    public static string TransliterateFromLvToEn(string name)
+    {
+        string translit = name;
+        translit = Regex.Replace(translit, @"(?<!1)1\.\s*$", @"1st");
+        translit = Regex.Replace(translit, @"(?<!1)2\.\s*$", @"2nd");
+        translit = Regex.Replace(translit, @"(?<!1)3\.\s*$", @"3rd");
+        translit = Regex.Replace(translit, @"(\d)\.\s*$", @"$1th");
+        return translit;
+    }
+
     private static string ReplaceWithPreserveCase(string str, string find, string replace)
     {
         string lowerFind = find.ToLower();

--- a/Osmalyzer/Runner.cs
+++ b/Osmalyzer/Runner.cs
@@ -72,7 +72,7 @@ public static class Runner
             new UnknownParcelLockerAnalyzer(),
             new LatviaPostLockerAnalyzer(),
             // new LatviaPostMailBoxAnalyzer(),
-            // new ImproperTranslationAnalyzer(),
+            new ImproperTranslationAnalyzer(),
             // new LidlShopAnalyzer(),
             new UnisendParcelLockerAnalyzer(),
             // new SpellingAnalyzer()

--- a/Osmalyzer/Runner.cs
+++ b/Osmalyzer/Runner.cs
@@ -65,16 +65,16 @@ public static class Runner
             // new WikidataSynchronicityAnalyzer(), -- disabled
             // new BarrierConnectionAnalyzer(),
             // new BottleDepositPointsAnalyzer(),
-            new VenipakParcelLockerAnalyzer(),
-            new OmnivaParcelLockerAnalyzer(),
-            new ItellaParcelLockerAnalyzer(),
-            new DPDParcelLockerAnalyzer(),
-            new UnknownParcelLockerAnalyzer(),
-            new LatviaPostLockerAnalyzer(),
+            // new VenipakParcelLockerAnalyzer(),
+            // new OmnivaParcelLockerAnalyzer(),
+            // new ItellaParcelLockerAnalyzer(),
+            // new DPDParcelLockerAnalyzer(),
+            // new UnknownParcelLockerAnalyzer(),
+            // new LatviaPostLockerAnalyzer(),
             // new LatviaPostMailBoxAnalyzer(),
             new ImproperTranslationAnalyzer(),
             // new LidlShopAnalyzer(),
-            new UnisendParcelLockerAnalyzer(),
+            // new UnisendParcelLockerAnalyzer(),
             // new SpellingAnalyzer()
         };
 #endif

--- a/data/street name qualifiers.tsv
+++ b/data/street name qualifiers.tsv
@@ -15,3 +15,4 @@ pārvads	переезд	crossing
 līnija	линия	line
 šķērslīnija	поперечная линия	cross line
 krastmala	набережная	waterfront
+stacija	станция	station

--- a/data/street name qualifiers.tsv
+++ b/data/street name qualifiers.tsv
@@ -12,3 +12,6 @@ apvedceļš	окружная дорога	bypass
 laukums	площадь	square
 prospekts	проспект	avenue
 pārvads	переезд	crossing
+līnija	линия	line
+šķērslīnija	поперечная линия	cross line
+krastmala	набережная	waterfront

--- a/data/street name suffixes.tsv
+++ b/data/street name suffixes.tsv
@@ -14,3 +14,6 @@ līnija
 šoseja
 aplis
 celiņš
+līnija
+šķērslīnija
+krastmala


### PR DESCRIPTION
Added list of unrecognized names
Changed transliteration of numbered streets: `1. līnija` -> `1st line`/`1-я линия`
Added `route=road`, `boundary=administrative` and `railway=station` to checks.