### PR TITLE
FIx time merging

### DIFF
--- a/Core/Helpers/OsmOpeningHoursHelper.cs
+++ b/Core/Helpers/OsmOpeningHoursHelper.cs
@@ -1,4 +1,7 @@
-﻿namespace Osmalyzer;
+﻿using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Osmalyzer;
 
 /// <summary>
 /// Utilities for working with OSM opening hours strings.
@@ -38,7 +41,7 @@ public static class OsmOpeningHoursHelper
                 continue;
             }
 
-            if (TimeMatches(previous, current))
+            if (TimeMatches(previous, current) && DaysSequential(previous, current))
             {
                 // Replace previous with the merged version
                 merged[merged.Count - 1] = MergeDays(previous, current);
@@ -67,6 +70,15 @@ public static class OsmOpeningHoursHelper
             string bTime = b[3..];
 
             return aTime == bTime;
+        }
+
+        bool DaysSequential(string a, string b)
+        {
+            string daysRegex = @"\b(?:Mo|Tu|We|Th|Fr|Sa|Su)\b";
+            List<string> daysOfWeek = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"];
+            string lastDayA = Regex.Matches(a, daysRegex).Last().Value;
+            string firstDayB = Regex.Match(b, daysRegex).Value;
+            return daysOfWeek.IndexOf(firstDayB) == daysOfWeek.IndexOf(lastDayA) + 1;
         }
 
         string MergeDays(string a, string b)


### PR DESCRIPTION
Function MergeDays at https://github.com/OSMLatvija/Osmalyzer/blob/main/Core/Helpers/OsmOpeningHoursHelper.cs#L72
behaves incorrectly when input is not in continuous blocks.

For example, input `"Tu 00:00-12:00","Th 00:00-12:00"` produces output `"Tu-Th 00:00-12:00"`

To solve this I've added one more check before merging days.

Impact: working hours of VPVKACs were wrong in a bunch of places. No they are shown in the report.