### PR TITLE
Add state police analyzer

### DIFF
--- a/Osmalyzer/Analyzers/AnalyzerGroup.cs
+++ b/Osmalyzer/Analyzers/AnalyzerGroup.cs
@@ -10,6 +10,7 @@ public class AnalyzerGroup
     public static AnalyzerGroup Restaurants { get; } = new AnalyzerGroup("Restaurants");
     public static AnalyzerGroup Validation { get; } = new AnalyzerGroup("Validation");
     public static AnalyzerGroup POIs { get; } = new AnalyzerGroup("POIs");
+    public static AnalyzerGroup StateServices { get; } = new AnalyzerGroup("State Services");
     public static AnalyzerGroup Administrative { get; } = new AnalyzerGroup("Administrative");
     public static AnalyzerGroup Miscellaneous { get; } = new AnalyzerGroup("Miscellaneous");
     

--- a/Osmalyzer/Analyzers/Misc Analyzers/CourthouseAnalyzer.cs
+++ b/Osmalyzer/Analyzers/Misc Analyzers/CourthouseAnalyzer.cs
@@ -7,7 +7,7 @@ public class CourthouseAnalyzer : Analyzer
 
     public override string Description => "This report checks that all official courthouses listed on government's website are found on the map.";
 
-    public override AnalyzerGroup Group => AnalyzerGroup.POIs;
+    public override AnalyzerGroup Group => AnalyzerGroup.StateServices;
 
 
     public override List<Type> GetRequiredDataTypes() => [ typeof(LatviaOsmAnalysisData), typeof(CourthouseAnalysisData) ];

--- a/Osmalyzer/Analyzers/Misc Analyzers/StatePoliceAnalyzer.cs
+++ b/Osmalyzer/Analyzers/Misc Analyzers/StatePoliceAnalyzer.cs
@@ -1,0 +1,56 @@
+﻿namespace Osmalyzer;
+
+[UsedImplicitly]
+public class StatePoliceAnalyzer : Analyzer
+{
+    public override string Name => "State police offices";
+
+    public override string Description => "This report checks that all state police offices listed on goverment's website are found on the map."; //+ Environment.NewLine +
+                                          //"Note that Latvijas pasts' website can and does have errors: mainly incorrect positions, but sometimes missing or phantom items too.";
+
+    public override AnalyzerGroup Group => AnalyzerGroup.StateServices;
+
+    public override List<Type> GetRequiredDataTypes() =>
+    [
+        typeof(LatviaOsmAnalysisData),
+        typeof(StatePoliceAnalysisData)
+    ];
+        
+
+    public override void Run(IReadOnlyList<AnalysisData> datas, Report report)
+    {
+        // Load OSM data
+
+        LatviaOsmAnalysisData osmData = datas.OfType<LatviaOsmAnalysisData>().First();
+
+        OsmData OsmData = osmData.MasterData;
+                
+        OsmData osmPoliceOffices = OsmData.Filter(
+            new HasAnyValue("amenity", "police"),
+            new InsidePolygon(BoundaryHelper.GetLatviaPolygon(osmData.MasterData), OsmPolygon.RelationInclusionCheck.FuzzyLoose) // a couple OOB hits
+        );
+
+        // Load post office data
+        List<StatePoliceData> listedPoliceOffices = datas.OfType<StatePoliceAnalysisData>().First().Offices;
+        
+        // Prepare data comparer/correlator
+        Correlator<StatePoliceData> correlator = new Correlator<StatePoliceData>(
+            osmPoliceOffices,
+            listedPoliceOffices,
+            new MatchDistanceParamater(100),
+            new MatchFarDistanceParamater(200),
+            new MatchExtraDistanceParamater(MatchStrength.Strong, 500),
+            new DataItemLabelsParamater("State police office", "State police offices"),
+            new OsmElementPreviewValue("name", true)
+        );
+        
+        // Parse and report primary matching and location correlation
+        CorrelatorReport correlatorReport = correlator.Parse(
+            report,
+            new MatchedPairBatch(),
+            new MatchedLoneOsmBatch(true),
+            new UnmatchedItemBatch(),
+            new MatchedFarPairBatch()
+        );
+    }
+}

--- a/Osmalyzer/Analyzers/Misc Analyzers/VPVKACAnalyzer.cs
+++ b/Osmalyzer/Analyzers/Misc Analyzers/VPVKACAnalyzer.cs
@@ -12,7 +12,7 @@ public class VPVKACAnalyzer : Analyzer
 
     public override string Description => "This report checks that VPVKAC (Valsts un pašvaldību vienotie klientu apkalpošanas centri) offices are mapped.";
 
-    public override AnalyzerGroup Group => AnalyzerGroup.POIs;
+    public override AnalyzerGroup Group => AnalyzerGroup.StateServices;
 
 
     public override List<Type> GetRequiredDataTypes() => [ typeof(LatviaOsmAnalysisData), typeof(VPVKACAnalysisData) ];

--- a/Osmalyzer/Data/Data Items/StatePoliceData.cs
+++ b/Osmalyzer/Data/Data Items/StatePoliceData.cs
@@ -1,0 +1,23 @@
+﻿namespace Osmalyzer;
+
+public class StatePoliceData : IDataItem
+{
+    public string OfficeName { get; }
+
+    public string Name => OfficeName;
+    
+    public OsmCoord Coord { get; }
+
+
+    public StatePoliceData(string officeName, OsmCoord coord)
+    {
+        Coord = coord;
+        OfficeName = officeName;
+    }
+    
+    
+    public string ReportString()
+    {
+        return OfficeName;
+    }
+}

--- a/Osmalyzer/Data/Misc Data Fetchers/StatePoliceAnalysisData.cs
+++ b/Osmalyzer/Data/Misc Data Fetchers/StatePoliceAnalysisData.cs
@@ -1,0 +1,61 @@
+﻿using System.Web;
+using Newtonsoft.Json;
+
+namespace Osmalyzer;
+
+[UsedImplicitly]
+public class StatePoliceAnalysisData : AnalysisData, IUndatedAnalysisData
+{
+    public override string Name => "StatePolice";
+
+    public override string ReportWebLink => @"https://www.vp.gov.lv/lv/valsts-policijas-apkalpojamas-teritorijas-un-iecirknu-pienemsanas-laiki#valsts-policijas-atrasanas-vietas";
+
+    public override bool NeedsPreparation => true;
+
+
+    protected override string DataFileIdentifier => "state-police";
+
+    private string DataFileName => Path.Combine(CacheBasePath, DataFileIdentifier + @".json");
+
+
+    public List<StatePoliceData> Offices { get; private set; } = null!; // only null before prepared
+
+
+    protected override void Download()
+    {
+        WebsiteDownloadHelper.Download(
+            "https://geolatvija.lv/api/v1/user-embeds/71648f8f-22b7-41cc-b06e-86028ec6938b/uuid", 
+            DataFileName
+        );
+    }
+
+    protected override void DoPrepare()
+    {
+        Offices = [ ];
+
+        string source = File.ReadAllText(DataFileName);
+        dynamic outerContent = JsonConvert.DeserializeObject(source)!;         
+        string innerSource = (string) outerContent.data;
+        dynamic innerContent = JsonConvert.DeserializeObject(innerSource)!;
+        // {
+        //     "uuid":"9182bc41-ee7c-42a6-b511-2ac83a7d0c85",
+        //     "coord":[
+        //         448684.228531708,
+        //         313777.3467708682
+        //     ],
+        //     "color":"#518B33",
+        //     "description":"Valsts policijas Zemgales reģiona pārvaldes Rietumzemgales iecirknis Tukumā"
+        // }, 
+        foreach (dynamic item in innerContent.markers)
+        {
+            double northing = item.coord[0];
+            double easting = item.coord[1];
+            (double lat, double lon) = CoordConversion.LKS92ToWGS84(northing, easting);
+            Offices.Add(
+                new StatePoliceData(
+                    (string)item.description,
+                    new OsmCoord(lat, lon)));
+        }
+    }
+
+}

--- a/Osmalyzer/Misc/CoordConversion.cs
+++ b/Osmalyzer/Misc/CoordConversion.cs
@@ -19,7 +19,7 @@ public static class CoordConversion
             new ProjectionParameter("central_meridian", 24),
             new ProjectionParameter("scale_factor", 0.9996),
             new ProjectionParameter("false_easting", 500000),
-            new ProjectionParameter("false_northing", 0)
+            new ProjectionParameter("false_northing", -6000000)
         ];
 
         IProjection? tm = csFactory.CreateProjection("Transverse_Mercator", "Transverse_Mercator", projParams);


### PR DESCRIPTION
Implements #65:
Adds analyzer for state police offices. Only checks for `amenity=police` to be present at expected location.
I didn't find a good way to differentiate from other police offices, so no "reverse" checks at the moment.

Also, separates state services into it's own group of reports.

Finally, fixes coordinates conversion from LKS-92.